### PR TITLE
Fix shell syntax.

### DIFF
--- a/horovod/run/gloo_run.py
+++ b/horovod/run/gloo_run.py
@@ -179,7 +179,7 @@ def _launch_jobs(settings, env, host_alloc_plan, remote_host_names, _run_command
                 '{local_command}'.format(
                     host=host_name,
                     ssh_port_arg=ssh_port_arg,
-                    local_command=quote('cd {pwd} >& /dev/null ; {local_command}'
+                    local_command=quote('cd {pwd} > /dev/null 2>&1 ; {local_command}'
                                         .format(pwd=os.getcwd(), local_command=local_command))
                 )
         args_list.append([command, alloc_info.rank, event])


### PR DESCRIPTION
Fix the invalid shell syntax in case python executes a shell script with `sh`.  This can happen in a nonroot container if the user account created for the user has `/bin/sh` as the default shell.