### PR TITLE
Tensorflow local gradient aggregation.

### DIFF
--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -215,6 +215,116 @@ def _make_allreduce_grads_fn(name, device_dense, device_sparse,
         return allreduce_grads
 
 
+class LocalGradientAggregationHelper:
+    def __init__(self, aggregation_frequency, allreduce_func):
+        self._allreduce_grads = allreduce_func
+
+        # How often are parameters synchronized
+        self.aggregation_frequency = aggregation_frequency
+        assert self.aggregation_frequency > 0
+
+        # This is going to be N data structure holding the aggregated gradient updates
+        # for parameter updates. N is the number of parameters.
+        self.gpu_shadow_vars = []
+
+        # Used to know when to allreduce and apply gradients. We allreduce when `self.counter`
+        # is equal to `self.aggregation_frequency`. We apply gradients when `self.counter` is
+        # equal to 0.
+        self.counter = None
+
+    def init_aggregation_vars(self, grads):
+        with tf.variable_scope("aggregation_variables"):
+            self.counter = tf.get_variable(
+                "aggregation_counter", shape=(), dtype=tf.int32,
+                trainable=False, initializer=tf.zeros_initializer())
+            if self.aggregation_frequency > 1:
+                for idx, grad in enumerate(grads):
+                    grad_aggregation_variable_name = str(idx)
+                    grad_aggregation_variable = tf.get_variable(
+                        grad_aggregation_variable_name, shape=grad.get_shape().as_list(),
+                        trainable=False, initializer=tf.zeros_initializer(), dtype=grad.dtype,
+                        collections=[tf.GraphKeys.LOCAL_VARIABLES, "aggregating_collection"])
+                    self.gpu_shadow_vars.append(grad_aggregation_variable)
+                assert len(self.gpu_shadow_vars) == len(grads)
+
+    def _clear_grads(self):
+        clear_ops_list = []
+        for idx, grad_aggregator in enumerate(self.gpu_shadow_vars):
+            clear_op = grad_aggregator.assign(
+                grad_aggregator.initial_value)
+            clear_ops_list.append(clear_op)
+        return tf.group(*clear_ops_list)
+
+    def _aggregate_grads(self, grads):
+        aggregation_ops_list = []
+        if self.aggregation_frequency > 1:
+            for idx, grad in enumerate(grads):
+                grad_aggregator = self.gpu_shadow_vars[idx]
+                updated_grad_aggregator = grad_aggregator.assign_add(grad)
+                aggregation_ops_list.append(updated_grad_aggregator)
+        return aggregation_ops_list
+
+    def _allreduce_grads_helper(self, grads):
+        if self.aggregation_frequency > 1:
+            # Read in latest variables values.
+            aggregated_grads = []
+            aggregation_read_ops_list = []
+            for idx, grad_aggregator in enumerate(self.gpu_shadow_vars):
+                aggregated_grads.append(
+                    grad_aggregator.read_value())
+                aggregation_read_ops_list.append(
+                    aggregated_grads[idx])
+            aggregation_read_ops = tf.group(
+                *aggregation_read_ops_list)
+        else:
+            aggregated_grads = grads
+            aggregation_read_ops = tf.no_op()
+
+        with tf.control_dependencies([aggregation_read_ops]):
+            averaged_gradients = self._allreduce_grads(aggregated_grads)
+            with tf.control_dependencies([g.op for g in averaged_gradients]):
+                reset_op = self.counter.assign(
+                    tf.constant(0), use_locking=True)
+            with tf.control_dependencies([reset_op]):
+                if self.aggregation_frequency > 1:
+                    return tuple(tf.divide(g, self.aggregation_frequency) for g in averaged_gradients)
+                else:
+                    # When grad updates are represented in `IndexedSlices`, we can not divide
+                    # them by int. Currently aggregation_frequency > 1 is not supported
+                    # `IndexedSlices`.
+                    return tuple(tf.identity(g) for g in averaged_gradients)
+
+    def compute_gradients(self, grads):
+        if self.aggregation_frequency > 1:
+            clear_op = tf.cond(tf.equal(self.counter, 0), lambda: self._clear_grads(), tf.no_op)
+            with tf.control_dependencies([clear_op]):
+                aggregation_ops_list = self._aggregate_grads(grads)
+
+            aggregation_ops = tf.group(*aggregation_ops_list)
+            with tf.control_dependencies([aggregation_ops]):
+                update_counter = self.counter.assign_add(tf.constant(1))
+        else:
+            update_counter = tf.no_op()
+
+        with tf.control_dependencies([update_counter]):
+            if self.aggregation_frequency > 1:
+                allreduced_grads = tf.cond(
+                    tf.equal(self.counter, self.aggregation_frequency),
+                    lambda: self._allreduce_grads_helper(grads),
+                    lambda: grads,
+                )
+            else:
+                allreduced_grads = self._allreduce_grads_helper(grads)
+
+        with tf.control_dependencies([tf.group(*allreduced_grads)]):
+            return tuple(tf.identity(grad) for grad in allreduced_grads)
+
+    def apply_gradients(self, apply_grads_closure, *args, **kwargs):
+        flattended_args0 = [item for tup in args[0] for item in tup]
+        with tf.control_dependencies([tf.group(*flattended_args0)]):
+            return tf.cond(tf.equal(self.counter, 0), apply_grads_closure, tf.no_op)
+
+
 try:
     # TensorFlow 2.x
     _LegacyOptimizer = tf.compat.v1.train.Optimizer
@@ -242,19 +352,7 @@ if _LegacyOptimizer is not None:
             self._allreduce_grads = _make_allreduce_grads_fn(
                 name, device_dense, device_sparse, compression, sparse_as_dense)
 
-
-            # How often are parameters synchronized
-            self._aggregation_frequency = aggregation_frequency
-            assert self._aggregation_frequency > 0
-
-            # This is going to be N data structure holding the aggregated gradient updates
-            # for parameter updates. N is the number of parameters.
-            self.gpu_shadow_vars = []
-
-            # Used to know when to allreduce and apply gradients. We allreduce when `self.counter`
-            # is equal to `self._aggregation_frequency`. We apply gradients when `self.counter` is
-            # equal to 0.
-            self.counter = None
+            self._agg_helper = LocalGradientAggregationHelper(aggregation_frequency, self._allreduce_grads)
 
         def compute_gradients(self, *args, **kwargs):
             """Compute gradients of all trainable variables.
@@ -264,118 +362,18 @@ if _LegacyOptimizer is not None:
             In DistributedOptimizer, compute_gradients() is overriden to also
             allreduce the gradients before returning them.
             """
-
-            def init_aggregation_vars():
-                with tf.variable_scope("aggregation_variables"):
-                    self.counter = tf.get_variable(
-                        "aggregation_counter", shape=(), dtype=tf.int32,
-                        trainable=False, initializer=tf.zeros_initializer())
-                    if self._aggregation_frequency > 1:
-                        for idx, grad in enumerate(self.grads):
-                            grad_aggregation_variable_name = str(idx)
-                            grad_aggregation_variable = tf.get_variable(
-                                grad_aggregation_variable_name, shape=grad.get_shape().as_list(),
-                                trainable=False, initializer=tf.zeros_initializer(), dtype=tf.float64,
-                                collections=[tf.GraphKeys.LOCAL_VARIABLES, "aggregating_collection"])
-                            self.gpu_shadow_vars.append(grad_aggregation_variable)
-                        assert len(self.gpu_shadow_vars) == len(self.grads)
-
-            def clear_grads():
-                clear_ops_list = []
-                for idx, grad in enumerate(self.gpu_shadow_vars):
-                    grad_aggregation_variable_name = str(idx)
-                    grad_aggregator = tf.get_variable(
-                        grad_aggregation_variable_name, dtype=tf.float64)
-                    clear_op = grad_aggregator.assign(
-                        grad_aggregator.initial_value)
-                    clear_ops_list.append(clear_op)
-                return tf.group(*clear_ops_list)
-
-            def aggregate_grads():
-                aggregation_ops_list = []
-                if self._aggregation_frequency > 1:
-                    for idx, grad in enumerate(self.grads):
-                        grad_aggregation_variable_name = str(idx)
-                        grad_aggregator = tf.get_variable(
-                            grad_aggregation_variable_name, dtype=tf.float64)
-                        update_op = grad_aggregator.assign_add(grad)
-                        aggregation_ops_list.append(update_op)
-                return aggregation_ops_list
-
-            def allreduce_grads():
-                if self._aggregation_frequency > 1:
-                    # Read in latest variables values.
-                    aggregated_grads = []
-                    aggregation_read_ops_list = []
-                    with tf.variable_scope("aggregation_variables", reuse=True):
-                        for idx, grad in enumerate(self.gpu_shadow_vars):
-                            grad_aggregation_variable_name = str(idx)
-                            grad_aggregator = tf.get_variable(
-                                grad_aggregation_variable_name, dtype=tf.float64)
-                            aggregated_grads.append(
-                                grad_aggregator.read_value())
-                            aggregation_read_ops_list.append(
-                                aggregated_grads[idx])
-                    aggregation_read_ops = tf.group(
-                        *aggregation_read_ops_list)
-                else:
-                    aggregated_grads = self.grads
-                    aggregation_read_ops = tf.no_op()
-
-                with tf.control_dependencies([aggregation_read_ops]):
-                    averaged_gradients = self._allreduce_grads(self.grads)
-                    with tf.control_dependencies([g.op for g in averaged_gradients]):
-                        reset_op = self.counter.assign(
-                            tf.constant(0), use_locking=True)
-                    with tf.control_dependencies([reset_op]):
-                        if self._aggregation_frequency > 1:
-                            return tuple(tf.divide(g, self._aggregation_frequency) for g in averaged_gradients)
-                        else:
-                            # When grad updates are represented in `IndexedSlices`, we can not divide
-                            # them by int. Currently _aggregation_frequency > 1 is not supported
-                            # `IndexedSlices`.
-                            return tuple(tf.identity(g) for g in averaged_gradients)
-
-
             gradients = self._optimizer.compute_gradients(*args, **kwargs)
             if size() > 1:
                 self.grads, vars = zip(*gradients)
-                init_aggregation_vars()
-
-                if self._aggregation_frequency > 1:
-                    with tf.variable_scope("aggregation_variables", reuse=True):
-                        clear_op = tf.cond(tf.equal(self.counter, 0), clear_grads, tf.no_op)
-                        with tf.control_dependencies([clear_op]):
-                            aggregation_ops_list = aggregate_grads()
-
-                        aggregation_ops = tf.group(*aggregation_ops_list)
-                        with tf.control_dependencies([aggregation_ops]):
-                            update_ops = [self.counter.assign_add(tf.constant(1))]
-                else:
-                    update_ops = [tf.no_op()]
-
-                with tf.control_dependencies(update_ops):
-                    if self._aggregation_frequency > 1:
-                        allreduced_grads = tf.cond(
-                            tf.equal(self.counter, self._aggregation_frequency),
-                            allreduce_grads,
-                            lambda: self.grads,
-                        )
-                    else:
-                        allreduced_grads = allreduce_grads()
-
-                with tf.control_dependencies([tf.group(*allreduced_grads)]):
-                    allreduced_grads = tuple(tf.identity(grad) for grad in allreduced_grads)
-
+                self._agg_helper.init_aggregation_vars(self.grads)
+                allreduced_grads = self._agg_helper.compute_gradients(self.grads)
                 return list(zip(allreduced_grads, vars))
             else:
                 return gradients
 
         def apply_gradients(self, *args, **kwargs):
-            """Calls this same method on the underlying optimizer."""
-            flattended_args0 = [item for tup in args[0] for item in tup]
-            with tf.control_dependencies([tf.group(*flattended_args0)]):
-                return tf.cond(tf.equal(self.counter, 0), lambda: self._optimizer.apply_gradients(*args, **kwargs), tf.no_op)
+            """Calls this same method from the local gradient aggregation helper."""
+            return self._agg_helper.apply_gradients(lambda: self._optimizer.apply_gradients(*args, **kwargs), *args, **kwargs)
 
         def get_slot(self, *args, **kwargs):
             """Calls this same method on the underlying optimizer."""


### PR DESCRIPTION
# Testing
I applied this patch to https://github.com/determined-ai/horovod/pull/10/commits/1889806baa120c15b5b9e5764d42a1a47168ccb4
```
diff --git a/horovod/tensorflow/__init__.py b/horovod/tensorflow/__init__.py
index 6632811..a38bd07 100644
--- a/horovod/tensorflow/__init__.py
+++ b/horovod/tensorflow/__init__.py
@@ -289,7 +289,7 @@ if _LegacyOptimizer is not None:
                     clear_op = grad_aggregator.assign(
                         grad_aggregator.initial_value)
                     clear_ops_list.append(clear_op)
-                return tf.group(*clear_ops_list)
+                with tf.control_dependencies([tf.print("CLEAR GRADS", self.counter)]):
+                     return tf.group(*clear_ops_list)

             def aggregate_grads():
@@ -297,9 +297,15 @@ if _LegacyOptimizer is not None:
                 if self._aggregation_frequency > 1:
                    for idx, grad in enumerate(self.grads):
                         grad_aggregation_variable_name = str(idx)
-                        grad_aggregator = tf.get_variable(
-                            grad_aggregation_variable_name, dtype=tf.float64)
-                        update_op = grad_aggregator.assign_add(grad)
+                        if idx == 0:
+                            print_op = tf.print("AGGREGATE GRADS", self.counter)
+                        else:
+                            print_op = tf.no_op()
+
+                        with tf.control_dependencies([print_op]):
+                            grad_aggregator = tf.get_variable(
+                                grad_aggregation_variable_name, dtype=tf.float64)
+                            update_op = grad_aggregator.assign_add(grad)
                         aggregation_ops_list.append(update_op)
                 return aggregation_ops_list

@@ -323,7 +329,7 @@ if _LegacyOptimizer is not None:
                     aggregated_grads = self.grads
                     aggregation_read_ops = tf.no_op()

-                with tf.control_dependencies([aggregation_read_ops]):
+                with tf.control_dependencies([aggregation_read_ops, tf.print("ALLREDUCE GRADS", self.counter)]):
                     averaged_gradients = self._allreduce_grads(self.grads)
                     with tf.control_dependencies([g.op for g in averaged_gradients]):
                         reset_op = self.counter.assign(
@@ -375,7 +381,7 @@ if _LegacyOptimizer is not None:
         def apply_gradients(self, *args, **kwargs):
             """Calls this same method on the underlying optimizer."""
             flattended_args0 = [item for tup in args[0] for item in tup]
-            with tf.control_dependencies([tf.group(*flattended_args0)]):
+            with tf.control_dependencies([tf.group(*flattended_args0), tf.print("APPLY GRADS", self.counter)]):
                 return tf.cond(tf.equal(self.counter, 0), lambda: self._optimizer.apply_gradients(*args, **kwargs), tf.no_op)

         def get_slot(self, *args, **kwargs):
```
and got the following expected output (excerpt) when using an aggregation frequency of 2 on 2 GPUs. Also confirmed that the final validation loss and accuracy on those two GPUs were equivalent.  (Horovod tensorflow_mnist_estimator.py example).
```
[1,1]<stderr>:AGGREGATE GRADS 0
[1,0]<stderr>:AGGREGATE GRADS 0
[1,0]<stderr>:APPLY GRADS 1
[1,0]<stderr>:AGGREGATE GRADS 1
[1,1]<stderr>:APPLY GRADS 1
[1,1]<stderr>:AGGREGATE GRADS 1
[1,0]<stderr>:ALLREDUCE GRADS 2
[1,1]<stderr>:ALLREDUCE GRADS 2
[1,0]<stderr>:APPLY GRADS 0
[1,1]<stderr>:APPLY GRADS 0
[1,1]<stderr>:CLEAR GRADS 0
[1,0]<stderr>:CLEAR GRADS 0
[1,1]<stderr>:AGGREGATE GRADS 0
[1,0]<stderr>:AGGREGATE GRADS 0
[1,0]<stderr>:APPLY GRADS 1
[1,1]<stderr>:APPLY GRADS 1
[1,0]<stderr>:AGGREGATE GRADS 1
[1,1]<stderr>:AGGREGATE GRADS 1
[1,0]<stderr>:ALLREDUCE GRADS 2
[1,1]<stderr>:ALLREDUCE GRADS 2
[1,0]<stderr>:APPLY GRADS 0
[1,1]<stderr>:APPLY GRADS 0
[1,1]<stderr>:CLEAR GRADS 0
[1,0]<stderr>:CLEAR GRADS 0
```

I tested "Refactor tf gradient aggregation." by running the tf estimator mnist example with aggregation frequency of 4 and verified that the model trained to a reasonable validation accuracy ~99% and that the validation metrics were the same on both GPUs.