### PR TITLE
Support configuring multiple SSH ports.

### DIFF
--- a/horovod/run/common/util/settings.py
+++ b/horovod/run/common/util/settings.py
@@ -16,14 +16,16 @@
 
 class Settings(object):
 
-    def __init__(self, verbose=0, ssh_port=None, extra_mpi_args=None, key=None, timeout=None,
-                 num_hosts=None, num_proc=None, hosts=None, output_filename=None,
+    def __init__(self, verbose=0, ssh_port=None, ssh_ports=None, extra_mpi_args=None, key=None,
+                 timeout=None, num_hosts=None, num_proc=None, hosts=None, output_filename=None,
                  run_func_mode=None, nic=None):
         """
         :param verbose: level of verbosity
         :type verbose: int
         :param ssh_port: SSH port on all the hosts
         :type ssh_port: int
+        :param ssh_ports: Comma separated SSH ports on all the hosts
+        :type ssh_ports: string
         :param extra_mpi_args: Extra MPI arguments to pass to mpirun
         :type extra_mpi_args: string
         :param key: used for encryption of parameters passed across the hosts
@@ -46,6 +48,7 @@ class Settings(object):
         """
         self.verbose = verbose
         self.ssh_port = ssh_port
+        self.ssh_ports = ssh_ports
         self.extra_mpi_args = extra_mpi_args
         self.key = key
         self.timeout = timeout


### PR DESCRIPTION
# Testing
Set up sshd on port 12346 for brian-hvd-2 and 12345 for brian-hvd-3, ran the below command on `brian-hvd-1` and verified it ran to completion.
``` 
NCCL_DEBUG=INFO horovodrun -np 6 -H brian-hvd-2:2,brian-hvd-1:2,brian-hvd-3:2 --ssh-ports 12346,12344,12345
--verbose python code/source/horovod/examples/tensorflow_keras_mnist.py
```