### PR TITLE
fix: don't use @tf.function for applying grads for eager execution [DET-3576]

### DIFF
--- a/horovod/common/gradient_aggregation_eager.py
+++ b/horovod/common/gradient_aggregation_eager.py
@@ -87,7 +87,5 @@ class LocalGradientAggregationHelperEager:
         for idx in self.shadow_var.keys():
             self.shadow_var[idx].assign_add(-1 * self.shadow_var[idx])
 
-    @tf.function
     def apply_gradients(self, apply_grads_closure, *args, **kwargs):
-        if tf.equal(self.counter, 0):
-            apply_grads_closure()
+        tf.cond(tf.equal(self.counter, 0), apply_grads_closure, tf.no_op)


### PR DESCRIPTION
Using @tf.function for applying grads was causing convergence issues for several models. Have verified convergence for fashion mnist and cifar for tf2. 