### PR TITLE
Correctly handle grads_and_vars passed in as zips for TF Keras 2.4 w/ local gradient aggregation (#2394)

### DIFF
--- a/horovod/_keras/__init__.py
+++ b/horovod/_keras/__init__.py
@@ -95,6 +95,14 @@ def create_distributed_optimizer(keras, optimizer, name, device_dense, device_sp
 
         def apply_gradients(self, *args, **kwargs):
             if self._agg_helper:
+                if isinstance(args[0], zip):
+                    # If grad_and_vars are passed in as a zip object
+                    # convert to a list. This is necessary for TF2.4+
+                    # b/c args[0] is used in both conditional branches
+                    # inside _agg_helper.apply_gradients().
+                    args = list(args)
+                    args[0] = list(args[0])
+                    args = tuple(args)
                 result = self._agg_helper.apply_gradients(
                     lambda: super(self.__class__, self).apply_gradients(*args, **kwargs),
                     self,


### PR DESCRIPTION
Signed-off-by: aaron276h <aaron@determined.ai>
(cherry picked from commit 744fbc935861d64ef4a57a8ab3828de8162df178)

**Note**: I ran the main repository's pre-commit tests using an image built from this patched version of Horovod. All looked good, except an unrelated failure that's been flaky all week: https://app.circleci.com/pipelines/github/determined-ai/determined/7517/workflows/c640ad07-7ba1-4fcb-ad8e-63a76d0ffef8