### PR TITLE
fix: handle parameters with None for grad for torch optimizer sync [DET-5243]

### DIFF
--- a/horovod/torch/optimizer.py
+++ b/horovod/torch/optimizer.py
@@ -142,6 +142,15 @@ class _DistributedOptimizer(torch.optim.Optimizer):
                     self._grad_accs.append(grad_acc)
 
     def _allreduce_grad_async(self, p):
+	if p.grad is None:
+            # Gradient was not computed, but we still need to submit a tensor to allreduce
+            # as one of the other ranks may have computed it (due to dynamic forward functions).
+            #
+            # NOTE: this will not work if the gradient is sparse and we perform an allgather.
+            # Unfrotunately, there doesn't appear to be a good way to detect that the parameter will
+            # produce sparse gradients before computing the gradient.
+            p.grad = p.data.new(p.size()).zero_()
+
         name = self._parameter_names.get(p)
         tensor = p.grad
         tensor_compressed, ctx = self._compression.compress(tensor)


### PR DESCRIPTION
We are missing fixes in stock horovod for handling of parameters with None for gradients during optimizer synchronize call.  
https://github.com/horovod/horovod/blob/master/horovod/torch/optimizer.py#L174